### PR TITLE
Stop using deprecated Buffer constructor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,12 +74,12 @@ var actorify = require('actorify');
 net.createServer(function(sock){
   var actor = actorify(sock);
 
-  var img = new Buffer('faux data');
+  var img = Buffer.from('faux data');
 
   actor.on('image thumbnails', function(img, sizes){
     console.log('%s byte image -> %s', img.length, sizes.join(', '));
     sizes.forEach(function(size){
-      actor.send('thumb', size, new Buffer('thumb data'));
+      actor.send('thumb', size, Buffer.from('thumb data'));
     });
   });
 }).listen(3000);
@@ -91,7 +91,7 @@ setInterval(function(){
   var actor = actorify(sock);
 
   console.log('send image for thumbs');
-  var img = new Buffer('faux image');
+  var img = Buffer.from('faux image');
   actor.send('image thumbnails', img, ['150x150', '300x300']);
 
   actor.on('thumb', function(size, img){

--- a/examples/fast-client.js
+++ b/examples/fast-client.js
@@ -4,7 +4,7 @@ var actorify = require('..');
 
 var sock = net.connect(3000, 'localhost');
 var actor = actorify(sock);
-var msg = new Buffer(Array(64).join('a'));
+var msg = Buffer.from(Array(64).join('a'));
 
 function next() {
   var n = 50;

--- a/examples/thumb-client.js
+++ b/examples/thumb-client.js
@@ -7,7 +7,7 @@ setInterval(function(){
   var actor = actorify(sock);
 
   console.log('send image for thumbs');
-  var img = new Buffer('faux image');
+  var img = Buffer.from('faux image');
   actor.send('image thumbnails', img, ['150x150', '300x300']);
 
   actor.on('thumb', function(size, img){

--- a/examples/thumb-service.js
+++ b/examples/thumb-service.js
@@ -5,12 +5,12 @@ var actorify = require('..');
 net.createServer(function(sock){
   var actor = actorify(sock);
 
-  var img = new Buffer('faux data');
+  var img = Buffer.from('faux data');
 
   actor.on('image thumbnails', function(img, sizes){
     console.log('%s byte image -> %s', img.length, sizes.join(', '));
     sizes.forEach(function(size){
-      actor.send('thumb', size, new Buffer('thumb data'));
+      actor.send('thumb', size, Buffer.from('thumb data'));
     });
   });
 }).listen(3000);

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ Actor.prototype.send = function(){
     }
 
     this.callbacks[id] = callback;
-    args.unshift(new Buffer(id));
+    args.unshift(Buffer.from(id));
   }
 
   var msg = new Message(args);

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('Actor#send()', function(){
         done();
       });
 
-      actor.send('thumb', '150x150', new Buffer('data'));
+      actor.send('thumb', '150x150', Buffer.from('data'));
     })
   })
 
@@ -149,7 +149,7 @@ describe('Actor#send()', function(){
         done();
       });
 
-      actor.send('hello', new Buffer('world'));
+      actor.send('hello', Buffer.from('world'));
     })
   })
 


### PR DESCRIPTION
The `new Buffer(string|number)` form was deemed an attack vector
and deprecated. All Node.js v6.x+ versions have the `.from()`,
`.alloc()` and `.allocUnsafe()` family of Buffer methods now.